### PR TITLE
The implemented draft is now managed by the IETF

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -19,6 +19,7 @@ use Symfony\Component\RateLimiter\NoLimiter;
 /**
  * An implementation of RequestRateLimiterInterface that
  * fits most use-cases.
+ * See https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  *


### PR DESCRIPTION
The implemented draft is now under the httpapi workgroup of the IETF.
Follow the ongoing work for updates.

| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Track a reference to the implemented ratelimit draft.